### PR TITLE
Fix CLI behavior with help and version commands

### DIFF
--- a/packages/caliper-cli/caliper.js
+++ b/packages/caliper-cli/caliper.js
@@ -30,9 +30,9 @@ let results = yargs
     .example('caliper bind\ncaliper unbind\ncaliper launch manager\ncaliper launch worker')
     .wrap(null)
     .epilogue('For more information on Hyperledger Caliper: https://hyperledger-caliper.github.io/caliper/')
-    .alias('version', 'v')
     .alias('help', 'h')
-    .version(version)
+    .version(version) // enabling the version command must come before its alias setting, otherwise -v will not work
+    .alias('version', 'v')
     .describe('version', 'Show version information')
     .describe('help', 'Show usage information')
     .strict(false)

--- a/packages/caliper-core/lib/common/config/Config.js
+++ b/packages/caliper-core/lib/common/config/Config.js
@@ -235,8 +235,15 @@ class Config {
 
         this._config.use('memory');
 
+        // NOTE: pass an explcit yargs instance to nconf,
+        // so we can override its default parsing behavior,
+        // and turn off the --help command, so Caliper can handle it.
+        // The previous parameters can be set on the yargs instance.
+        let yargsInstace = require('yargs').help(false);
         // normalize the argument names to be more robust
-        this._config.argv({ parseValues: true, transform: normalizeSettingKey });
+        yargsInstace.transform = normalizeSettingKey;
+        yargsInstace.parseValues = true;
+        this._config.argv(yargsInstace);
 
         // normalize the argument names to be more robust
         this._config.env({ parseValues: true, transform: normalizeSettingKey });


### PR DESCRIPTION
Fixes #1661 

The main issue is that we hit our `Config` construction below before __our__ `yargs` instance could parse and execute the help command:

https://github.com/hyperledger-caliper/caliper/blob/c02c225f24038d6aaa9890fac35ad1a66221f43d/packages/caliper-core/lib/common/config/Config.js#L239

I considered multiple options to fix this (handle the help command directly, play around with `yargs` build order, the impossible task of ensuring that nconf is not called during our `yargs` construction...), but the most robust was changing how `nconf`'s own `yargs` instance behaves here when it parses the `help` parameter and terminates the CLI process early:

https://github.com/indexzero/nconf/blob/87e07262d9425a80d57990e2a9cbdaebcadf2e05/lib/nconf/stores/argv.js#L72

To influence this, the proposed solution passes a __customized__ `yargs` instance to `nconf` where the help command is disabled explicitly, but other parsing options are retained (just passed in another way).

Also, I moved the `version` alias setting __after__ the build step where the `version` command is enabled; otherwise, the alias was ignored for a not-yet-existing key.
