### PR TITLE
fix: NPM publishing with workspaces (#1714)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,15 +25,6 @@ jobs:
             - 'packages/caliper-tests-integration/fabric_tests/**'
             - '.github/workflows/integration-tests.yml'
             - 'package-lock.json'
-          generator:
-            - 'packages/caliper-cli/**'
-            - 'packages/caliper-core/**'
-            - 'packages/caliper-fabric/**'
-            - 'packages/generator-caliper/**'
-            - 'packages/caliper-publish/**'
-            - 'packages/caliper-tests-integration/generator_tests/**'
-            - '.github/workflows/integration-tests.yml'
-            - 'package-lock.json'
 
   integration-tests:
     needs: changes

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "type": "git",
         "url": "https://github.com/hyperledger-caliper/caliper"
     },
+    "private": true,
     "scripts": {
         "pretest": "npm run licchk --workspaces",
         "licchk": "license-check-and-add",

--- a/packages/caliper-cli/package.json
+++ b/packages/caliper-cli/package.json
@@ -4,7 +4,7 @@
     "version": "0.6.1-unstable",
     "repository": {
         "type": "git",
-        "url": "https://github.com/hyperledger-caliper/caliper",
+        "url": "git+https://github.com/hyperledger-caliper/caliper.git",
         "directory": "packages/caliper-cli"
     },
     "bin": {

--- a/packages/caliper-core/package.json
+++ b/packages/caliper-core/package.json
@@ -4,7 +4,7 @@
     "version": "0.6.1-unstable",
     "repository": {
         "type": "git",
-        "url": "https://github.com/hyperledger-caliper/caliper",
+        "url": "git+https://github.com/hyperledger-caliper/caliper.git",
         "directory": "packages/caliper-core"
     },
     "publishConfig": {

--- a/packages/caliper-fabric/package.json
+++ b/packages/caliper-fabric/package.json
@@ -4,7 +4,7 @@
     "version": "0.6.1-unstable",
     "repository": {
         "type": "git",
-        "url": "https://github.com/hyperledger-caliper/caliper",
+        "url": "git+https://github.com/hyperledger-caliper/caliper.git",
         "directory": "packages/caliper-fabric"
     },
     "publishConfig": {

--- a/packages/caliper-publish/artifacts/npm-publish.sh
+++ b/packages/caliper-publish/artifacts/npm-publish.sh
@@ -15,6 +15,7 @@
 
 # Exit on first error, print all commands.
 set -e
+set -x
 set -o pipefail
 
 # Set ARCH
@@ -23,7 +24,7 @@ ARCH=`uname -m`
 if [[ -z "${NPM_REGISTRY}" ]]
 then
     # Set the public NPM registry as default
-    npm config set registry https://registry.npmjs.org/
+    npm --workspaces=false config set registry https://registry.npmjs.org/
 fi
 
 npm publish --access public ${NPM_REGISTRY} ${DRY_RUN} --tag ${TAG}

--- a/packages/caliper-publish/lib/impl/npm.js
+++ b/packages/caliper-publish/lib/impl/npm.js
@@ -21,8 +21,7 @@ const utils = require('./../utils/cmdutils');
 const packages = [
     'caliper-core',
     'caliper-fabric',
-    'caliper-cli',
-    'generator-caliper'
+    'caliper-cli'
 ];
 
 // impl => lib => caliper-publish

--- a/packages/generator-caliper/package.json
+++ b/packages/generator-caliper/package.json
@@ -6,7 +6,7 @@
     "homepage": "https://hyperledger-caliper.github.io/caliper/",
     "repository": {
         "type": "git",
-        "url": "https://github.com/hyperledger-caliper/caliper"
+        "url": "git+https://github.com/hyperledger-caliper/caliper.git"
     },
     "main": "generators/callback/index.js",
     "keywords": [


### PR DESCRIPTION
Fixes #1714 

* tell the npm config command explicitly that it does not operate with workspaces
* set root package to private to prevent accidental publishing of monorepo
* updated git repo naming format in package.json files
